### PR TITLE
Fix spc import only imports channel 0.

### DIFF
--- a/focuspoint/import_methods/import_methods.py
+++ b/focuspoint/import_methods/import_methods.py
@@ -56,7 +56,7 @@ def spc_file_import(file_path):
             overflow += 4096
         if INVALID == 1:
             count1 +=1
-        elif int(byte1[0:4],2) == 0:
+        else: #elif int(byte1[0:4],2) == 0:
             chan_arr.append(int(byte1[0:4],2))
             true_time_arr.append(int(byte1[4:8]+byte0,2)+overflow)
             dtime_arr.append(4095 - int(byte3[4:8]+byte2,2))


### PR DESCRIPTION
Seems like `int(byte1[0:4],2)` is the channel number and the elif would ignore all counts not in channel 0. 